### PR TITLE
YARN-10929. Do not use a separate config in legacy CS AQC.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractCSQueue.java
@@ -323,12 +323,12 @@ public abstract class AbstractCSQueue implements CSQueue {
     return this.queueNodeLabelsSettings.getDefaultLabelExpression();
   }
 
-  protected void setupQueueConfigs(Resource clusterResource,
-      CapacitySchedulerConfiguration configuration) throws
+  protected void setupQueueConfigs(Resource clusterResource) throws
       IOException {
 
     writeLock.lock();
     try {
+      CapacitySchedulerConfiguration configuration = queueContext.getConfiguration();
       if (isDynamicQueue() || this instanceof AbstractAutoCreatedLeafQueue) {
         setDynamicQueueProperties(configuration);
       }
@@ -348,10 +348,7 @@ public abstract class AbstractCSQueue implements CSQueue {
 
       // Setup queue's maximumAllocation respecting the global
       // and the queue settings
-      // TODO remove the getSchedulerConfiguration() param after the AQC configuration duplication
-      //  removal is resolved
-      this.queueAllocationSettings.setupMaximumAllocation(configuration,
-          queueContext.getConfiguration(), getQueuePath(),
+      this.queueAllocationSettings.setupMaximumAllocation(configuration, getQueuePath(),
           parent);
 
       // Initialize the queue state based on previous state, configured state
@@ -376,10 +373,7 @@ public abstract class AbstractCSQueue implements CSQueue {
           this, labelManager, null);
 
       // Store preemption settings
-      // TODO remove the getSchedulerConfiguration() param after the AQC configuration duplication
-      //  removal is resolved
-      this.preemptionSettings = new CSQueuePreemptionSettings(this, configuration,
-          queueContext.getConfiguration());
+      this.preemptionSettings = new CSQueuePreemptionSettings(this, configuration);
       this.priority = configuration.getQueuePriority(
           getQueuePath());
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractLeafQueue.java
@@ -166,15 +166,12 @@ public class AbstractLeafQueue extends AbstractCSQueue {
   }
 
   @SuppressWarnings("checkstyle:nowhitespaceafter")
-  protected void setupQueueConfigs(Resource clusterResource,
-      CapacitySchedulerConfiguration conf) throws
+  protected void setupQueueConfigs(Resource clusterResource) throws
       IOException {
     writeLock.lock();
     try {
-      // TODO conf parameter can be a modified configuration with template entries and missing
-      //  some global configs. This config duplication needs to be removed.
-      CapacitySchedulerConfiguration originalConfiguration = queueContext.getConfiguration();
-      super.setupQueueConfigs(clusterResource, conf);
+      CapacitySchedulerConfiguration configuration = queueContext.getConfiguration();
+      super.setupQueueConfigs(clusterResource);
 
       this.lastClusterResource = clusterResource;
 
@@ -189,26 +186,26 @@ public class AbstractLeafQueue extends AbstractCSQueue {
       setQueueResourceLimitsInfo(clusterResource);
 
       setOrderingPolicy(
-          conf.<FiCaSchedulerApp>getAppOrderingPolicy(getQueuePath()));
+          configuration.<FiCaSchedulerApp>getAppOrderingPolicy(getQueuePath()));
 
-      usersManager.setUserLimit(conf.getUserLimit(getQueuePath()));
-      usersManager.setUserLimitFactor(conf.getUserLimitFactor(getQueuePath()));
+      usersManager.setUserLimit(configuration.getUserLimit(getQueuePath()));
+      usersManager.setUserLimitFactor(configuration.getUserLimitFactor(getQueuePath()));
 
       maxAMResourcePerQueuePercent =
-          conf.getMaximumApplicationMasterResourcePerQueuePercent(
+          configuration.getMaximumApplicationMasterResourcePerQueuePercent(
               getQueuePath());
 
-      maxApplications = conf.getMaximumApplicationsPerQueue(getQueuePath());
+      maxApplications = configuration.getMaximumApplicationsPerQueue(getQueuePath());
       if (maxApplications < 0) {
         int maxGlobalPerQueueApps =
-            conf.getGlobalMaximumApplicationsPerQueue();
+            configuration.getGlobalMaximumApplicationsPerQueue();
         if (maxGlobalPerQueueApps > 0) {
           maxApplications = maxGlobalPerQueueApps;
         }
       }
 
-      priorityAcls = conf.getPriorityAcls(getQueuePath(),
-          originalConfiguration.getClusterLevelApplicationMaxPriority());
+      priorityAcls = configuration.getPriorityAcls(getQueuePath(),
+          configuration.getClusterLevelApplicationMaxPriority());
 
       Set<String> accessibleNodeLabels = this.queueNodeLabelsSettings.getAccessibleNodeLabels();
       if (!SchedulerUtils.checkQueueLabelExpression(accessibleNodeLabels,
@@ -224,10 +221,10 @@ public class AbstractLeafQueue extends AbstractCSQueue {
                         .join(getAccessibleNodeLabels().iterator(), ',')));
       }
 
-      nodeLocalityDelay = originalConfiguration.getNodeLocalityDelay();
-      rackLocalityAdditionalDelay = originalConfiguration
+      nodeLocalityDelay = configuration.getNodeLocalityDelay();
+      rackLocalityAdditionalDelay = configuration
           .getRackLocalityAdditionalDelay();
-      rackLocalityFullReset = originalConfiguration
+      rackLocalityFullReset = configuration
           .getRackLocalityFullReset();
 
       // re-init this since max allocation could have changed
@@ -250,10 +247,10 @@ public class AbstractLeafQueue extends AbstractCSQueue {
       }
 
       defaultAppPriorityPerQueue = Priority.newInstance(
-          conf.getDefaultApplicationPriorityConfPerQueue(getQueuePath()));
+          configuration.getDefaultApplicationPriorityConfPerQueue(getQueuePath()));
 
       // Validate leaf queue's user's weights.
-      float queueUserLimit = Math.min(100.0f, conf.getUserLimit(getQueuePath()));
+      float queueUserLimit = Math.min(100.0f, configuration.getUserLimit(getQueuePath()));
       getUserWeights().validateForLeafQueue(queueUserLimit, getQueuePath());
       usersManager.updateUserWeights();
 
@@ -529,9 +526,8 @@ public class AbstractLeafQueue extends AbstractCSQueue {
     }
   }
 
-  protected void reinitialize(
-      CSQueue newlyParsedQueue, Resource clusterResource,
-      CapacitySchedulerConfiguration configuration) throws
+  @Override
+  public void reinitialize(CSQueue newlyParsedQueue, Resource clusterResource) throws
       IOException {
 
     writeLock.lock();
@@ -565,18 +561,10 @@ public class AbstractLeafQueue extends AbstractCSQueue {
             + newMax);
       }
 
-      setupQueueConfigs(clusterResource, configuration);
+      setupQueueConfigs(clusterResource);
     } finally {
       writeLock.unlock();
     }
-  }
-
-  @Override
-  public void reinitialize(
-      CSQueue newlyParsedQueue, Resource clusterResource)
-      throws IOException {
-    reinitialize(newlyParsedQueue, clusterResource,
-        queueContext.getConfiguration());
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AbstractManagedParentQueue.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerDynamicEditException;
 
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common
@@ -55,7 +54,7 @@ public abstract class AbstractManagedParentQueue extends ParentQueue {
     writeLock.lock();
     try {
       // Set new configs
-      setupQueueConfigs(clusterResource, queueContext.getConfiguration());
+      setupQueueConfigs(clusterResource);
 
     } finally {
       writeLock.unlock();
@@ -175,22 +174,12 @@ public abstract class AbstractManagedParentQueue extends ParentQueue {
     CapacitySchedulerConfiguration leafQueueConfigs = new
         CapacitySchedulerConfiguration(new Configuration(false), false);
 
-    Map<String, String> rtProps = queueContext
-        .getConfiguration().getConfigurationProperties()
-        .getPropertiesWithPrefix(YarnConfiguration.RESOURCE_TYPES + ".", true);
-    for (Map.Entry<String, String> entry : rtProps.entrySet()) {
-      leafQueueConfigs.set(entry.getKey(), entry.getValue());
-    }
-
     Map<String, String> templateConfigs = queueContext
         .getConfiguration().getConfigurationProperties()
         .getPropertiesWithPrefix(configPrefix, true);
 
-    for (final Iterator<Map.Entry<String, String>> iterator =
-         templateConfigs.entrySet().iterator(); iterator.hasNext(); ) {
-      Map.Entry<String, String> confKeyValuePair = iterator.next();
-      leafQueueConfigs.set(confKeyValuePair.getKey(),
-          confKeyValuePair.getValue());
+    for (Map.Entry<String, String> confKeyValuePair : templateConfigs.entrySet()) {
+      leafQueueConfigs.set(confKeyValuePair.getKey(), confKeyValuePair.getValue());
     }
 
     return leafQueueConfigs;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedLeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/AutoCreatedLeafQueue.java
@@ -42,7 +42,8 @@ public class AutoCreatedLeafQueue extends AbstractAutoCreatedLeafQueue {
   public AutoCreatedLeafQueue(CapacitySchedulerQueueContext queueContext, String queueName,
       ManagedParentQueue parent) throws IOException {
     super(queueContext, queueName, parent, null);
-    super.setupQueueConfigs(queueContext.getClusterResource(), parent.getLeafQueueConfigs(queueName));
+    parent.setLeafQueueConfigs(queueName);
+    super.setupQueueConfigs(queueContext.getClusterResource());
 
     LOG.debug("Initialized AutoCreatedLeafQueue: name={}, fullname={}", queueName, getQueuePath());
     updateCapacitiesToZero();
@@ -57,8 +58,8 @@ public class AutoCreatedLeafQueue extends AbstractAutoCreatedLeafQueue {
 
       ManagedParentQueue managedParentQueue = (ManagedParentQueue) parent;
 
-      super.reinitialize(newlyParsedQueue, clusterResource, managedParentQueue
-          .getLeafQueueConfigs(newlyParsedQueue.getQueueShortName()));
+      managedParentQueue.setLeafQueueConfigs(newlyParsedQueue.getQueueShortName());
+      super.reinitialize(newlyParsedQueue, clusterResource);
 
       //Reset capacities to 0 since reinitialize above
       // queueCapacities to initialize to configured capacity which might

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueuePreemptionSettings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CSQueuePreemptionSettings.java
@@ -26,13 +26,10 @@ public class CSQueuePreemptionSettings {
 
   public CSQueuePreemptionSettings(
       CSQueue queue,
-      CapacitySchedulerConfiguration configuration,
-      CapacitySchedulerConfiguration originalSchedulerConfiguration) {
-    this.preemptionDisabled = isQueueHierarchyPreemptionDisabled(queue, configuration,
-        originalSchedulerConfiguration);
+      CapacitySchedulerConfiguration configuration) {
+    this.preemptionDisabled = isQueueHierarchyPreemptionDisabled(queue, configuration);
     this.intraQueuePreemptionDisabledInHierarchy =
-        isIntraQueueHierarchyPreemptionDisabled(queue, configuration,
-            originalSchedulerConfiguration);
+        isIntraQueueHierarchyPreemptionDisabled(queue, configuration);
   }
 
   /**
@@ -46,10 +43,9 @@ public class CSQueuePreemptionSettings {
    * @return true if queue has cross-queue preemption disabled, false otherwise
    */
   private boolean isQueueHierarchyPreemptionDisabled(CSQueue q,
-      CapacitySchedulerConfiguration configuration,
-      CapacitySchedulerConfiguration originalSchedulerConfiguration) {
+      CapacitySchedulerConfiguration configuration) {
     boolean systemWidePreemption =
-        originalSchedulerConfiguration
+        configuration
             .getBoolean(YarnConfiguration.RM_SCHEDULER_ENABLE_MONITORS,
                 YarnConfiguration.DEFAULT_RM_SCHEDULER_ENABLE_MONITORS);
     CSQueue parentQ = q.getParent();
@@ -62,7 +58,7 @@ public class CSQueuePreemptionSettings {
     // on, then q does not have preemption disabled (default=false, below)
     // unless the preemption_disabled property is explicitly set.
     if (parentQ == null) {
-      return originalSchedulerConfiguration.getPreemptionDisabled(q.getQueuePath(), false);
+      return configuration.getPreemptionDisabled(q.getQueuePath(), false);
     }
 
     // If this is not the root queue, inherit the default value for the
@@ -85,10 +81,9 @@ public class CSQueuePreemptionSettings {
    * @return true if queue has intra-queue preemption disabled, false otherwise
    */
   private boolean isIntraQueueHierarchyPreemptionDisabled(CSQueue q,
-      CapacitySchedulerConfiguration configuration,
-      CapacitySchedulerConfiguration originalSchedulerConfiguration) {
+      CapacitySchedulerConfiguration configuration) {
     boolean systemWideIntraQueuePreemption =
-        originalSchedulerConfiguration.getBoolean(
+        configuration.getBoolean(
             CapacitySchedulerConfiguration.INTRAQUEUE_PREEMPTION_ENABLED,
             CapacitySchedulerConfiguration
                 .DEFAULT_INTRAQUEUE_PREEMPTION_ENABLED);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueContext.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/CapacitySchedulerQueueContext.java
@@ -100,6 +100,10 @@ public class CapacitySchedulerQueueContext {
     return configuration;
   }
 
+  public void setConfigurationEntry(String name, String value) {
+    this.configuration.set(name, value);
+  }
+
   public Resource getMinimumAllocation() {
     return minimumAllocation;
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/LeafQueue.java
@@ -41,7 +41,7 @@ public class LeafQueue extends AbstractLeafQueue {
       IOException {
     super(queueContext, queueName, parent, old, isDynamic);
 
-    setupQueueConfigs(queueContext.getClusterResource(), queueContext.getConfiguration());
+    setupQueueConfigs(queueContext.getClusterResource());
 
     LOG.debug("Initialized LeafQueue: name={}, fullname={}", queueName,
         getQueuePath());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ManagedParentQueue.java
@@ -17,13 +17,11 @@
  */
 package org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceLimits;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler
     .SchedulerDynamicEditException;
-import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.AbstractCSQueue.CapacityConfigType;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.queuemanagement.GuaranteedOrZeroCapacityOverTimePolicy;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.common.fica
     .FiCaSchedulerApp;
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -461,25 +458,13 @@ public class ManagedParentQueue extends AbstractManagedParentQueue {
     }
   }
 
-  public CapacitySchedulerConfiguration getLeafQueueConfigs(
-      String leafQueueName) {
-    return getLeafQueueConfigs(getLeafQueueTemplate().getLeafQueueConfigs(),
-        leafQueueName);
-  }
-
-  public CapacitySchedulerConfiguration getLeafQueueConfigs(
-      CapacitySchedulerConfiguration templateConfig, String leafQueueName) {
-    CapacitySchedulerConfiguration leafQueueConfigTemplate = new
-        CapacitySchedulerConfiguration(new Configuration(false), false);
-    for (final Iterator<Map.Entry<String, String>> iterator =
-         templateConfig.iterator(); iterator.hasNext();) {
-      Map.Entry<String, String> confKeyValuePair = iterator.next();
-      final String name = confKeyValuePair.getKey().replaceFirst(
-          CapacitySchedulerConfiguration
-              .AUTO_CREATED_LEAF_QUEUE_TEMPLATE_PREFIX,
-          leafQueueName);
-      leafQueueConfigTemplate.set(name, confKeyValuePair.getValue());
+  public void setLeafQueueConfigs(String leafQueueName) {
+    CapacitySchedulerConfiguration templateConfig = leafQueueTemplate.getLeafQueueConfigs();
+    for (Map.Entry<String, String> confKeyValuePair : templateConfig) {
+      final String name = confKeyValuePair.getKey()
+          .replaceFirst(CapacitySchedulerConfiguration.AUTO_CREATED_LEAF_QUEUE_TEMPLATE_PREFIX,
+              leafQueueName);
+      queueContext.setConfigurationEntry(name, confKeyValuePair.getValue());
     }
-    return leafQueueConfigTemplate;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ParentQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ParentQueue.java
@@ -134,7 +134,7 @@ public class ParentQueue extends AbstractCSQueue {
         queueContext.getConfiguration()
             .getAllowZeroCapacitySum(getQueuePath());
 
-    setupQueueConfigs(queueContext.getClusterResource(), queueContext.getConfiguration());
+    setupQueueConfigs(queueContext.getClusterResource());
 
     LOG.debug("Initialized ParentQueue: name={}, fullname={}", queueName, getQueuePath());
   }
@@ -146,14 +146,14 @@ public class ParentQueue extends AbstractCSQueue {
         queueOrderingPolicy.getConfigName();
   }
 
-  protected void setupQueueConfigs(Resource clusterResource,
-      CapacitySchedulerConfiguration configuration)
+  protected void setupQueueConfigs(Resource clusterResource)
       throws IOException {
     writeLock.lock();
     try {
+      CapacitySchedulerConfiguration configuration = queueContext.getConfiguration();
       autoCreatedQueueTemplate = new AutoCreatedQueueTemplate(
           configuration, getQueuePath());
-      super.setupQueueConfigs(clusterResource, configuration);
+      super.setupQueueConfigs(clusterResource);
       StringBuilder aclsString = new StringBuilder();
       for (Map.Entry<AccessType, AccessControlList> e : getACLs().entrySet()) {
         aclsString.append(e.getKey()).append(":")
@@ -635,7 +635,7 @@ public class ParentQueue extends AbstractCSQueue {
       ParentQueue newlyParsedParentQueue = (ParentQueue) newlyParsedQueue;
 
       // Set new configs
-      setupQueueConfigs(clusterResource, queueContext.getConfiguration());
+      setupQueueConfigs(clusterResource);
 
       // Re-configure existing child queues and add new ones
       // The CS has already checked to ensure all existing child queues are present!

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/PlanQueue.java
@@ -104,7 +104,7 @@ public class PlanQueue extends AbstractManagedParentQueue {
       }
 
       // Set new configs
-      setupQueueConfigs(clusterResource, queueContext.getConfiguration());
+      setupQueueConfigs(clusterResource);
 
       updateQuotas(newlyParsedParentQueue.userLimit,
           newlyParsedParentQueue.userLimitFactor,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueAllocationSettings.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/QueueAllocationSettings.java
@@ -36,17 +36,10 @@ public class QueueAllocationSettings {
     this.minimumAllocation = minimumAllocation;
   }
 
-  void setupMaximumAllocation(CapacitySchedulerConfiguration configuration,
-      CapacitySchedulerConfiguration originalSchedulerConfiguration, String queuePath,
+  void setupMaximumAllocation(CapacitySchedulerConfiguration configuration, String queuePath,
       CSQueue parent) {
-    /* YARN-10869: When using AutoCreatedLeafQueues, the passed configuration
-     * object is a cloned one containing only the template configs
-     * (see ManagedParentQueue#getLeafQueueConfigs). To ensure that the actual
-     * cluster maximum allocation is fetched the original config object should
-     * be used.
-     */
     Resource clusterMax = ResourceUtils
-        .fetchMaximumAllocationFromConfig(originalSchedulerConfiguration);
+        .fetchMaximumAllocationFromConfig(configuration);
     Resource queueMax = configuration.getQueueMaximumAllocation(queuePath);
 
     maximumAllocation = Resources.clone(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ReservationQueue.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/scheduler/capacity/ReservationQueue.java
@@ -39,8 +39,7 @@ public class ReservationQueue extends AbstractAutoCreatedLeafQueue {
   public ReservationQueue(CapacitySchedulerQueueContext queueContext, String queueName,
       PlanQueue parent) throws IOException {
     super(queueContext, queueName, parent, null);
-    super.setupQueueConfigs(queueContext.getClusterResource(),
-        queueContext.getConfiguration());
+    super.setupQueueConfigs(queueContext.getClusterResource());
 
     LOG.debug("Initialized ReservationQueue: name={}, fullname={}",
         queueName, getQueuePath());


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

